### PR TITLE
Updated setup.py for ssh error while cloning.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ KENLM_COMMIT = '96d303cfb1a0c21b8f060dbad640d7ab301c019a'
 # Packages required in 'production'
 REQUIRED = [
     'tqdm==4.39.0',
-    'kenlm @ git+ssh://git@github.com/kpu/kenlm@{}#egg=kenlm'.format(
+    'kenlm @ git+https://git@github.com/kpu/kenlm@{}#egg=kenlm'.format(
         KENLM_COMMIT
     ),
     'numpy==1.16.2',


### PR DESCRIPTION
Hello. Matthias. First, I would like to thank you for this amazing tool. 

I have updated setup.py because when I try to install the package I got the below error. Hence, I made this change.

```
Processing /home/sunil/temp_ctc_decoder_test/py-ctc-decode
Collecting kenlm@ git+ssh://git@github.com/kpu/kenlm@96d303cfb1a0c21b8f060dbad640d7ab301c019a#egg=kenlm
  Cloning ssh://****@github.com/kpu/kenlm (to revision 96d303cfb1a0c21b8f060dbad640d7ab301c019a) to /tmp/pip-install-yj7qrtj7/kenlm
  Running command git clone -q 'ssh://****@github.com/kpu/kenlm' /tmp/pip-install-yj7qrtj7/kenlm
The authenticity of host 'github.com (13.234.176.102)' can't be established.
ECDSA key fingerprint is SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
  Warning: Permanently added 'github.com,13.234.176.102' (ECDSA) to the list of known hosts.
  git@github.com: Permission denied (publickey).
  fatal: Could not read from remote repository.

  Please make sure you have the correct access rights
  and the repository exists.
ERROR: Command errored out with exit status 128: git clone -q 'ssh://****@github.com/kpu/kenlm' /tmp/pip-install-yj7qrtj7/kenlm Check the logs for full command output.
```

